### PR TITLE
Fix for Windows: use path.sep instead of /

### DIFF
--- a/lib/babel-module-template.js
+++ b/lib/babel-module-template.js
@@ -1,4 +1,5 @@
 'use strict';
+const path = require('path');
 const babel = require('babel-core');
 const sources = require('webpack-sources');
 const readPkgUp = require('read-pkg-up');
@@ -28,7 +29,7 @@ class BabelModuleTemplate {
 
 	apply(moduleTemplate) {
 		moduleTemplate.plugin('module', (source, module) => {
-			if (module.context !== null && module.context.indexOf('/node_modules/') === -1) {
+			if (module.context !== null && module.context.indexOf(`${path.sep}node_modules${path.sep}`) === -1) {
 				return source;
 			}
 


### PR DESCRIPTION
I tested this package on Linux and it works great, but it failed to work on Windows.

After digging a bit, I discovered that the code is using / as path separator which unfortunately doesn't work on Windows.
This uses [path.sep](https://nodejs.org/api/path.html#path_path_sep) to make it work cross platform.