### PR TITLE
Fix CI failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
+  - '10'
   - '8'
   - '6'
-  - '4'

--- a/lib/babel-module-template.js
+++ b/lib/babel-module-template.js
@@ -5,7 +5,7 @@ const sources = require('webpack-sources');
 const readPkgUp = require('read-pkg-up');
 const semver = require('semver');
 
-const RawSource = sources.RawSource;
+const {RawSource} = sources;
 
 const logs = new Set();
 
@@ -36,7 +36,7 @@ class BabelModuleTemplate {
 			let range = this._engines.get(module.context);
 
 			if (range === undefined) {
-				const pkg = readPkgUp.sync({cwd: module.context, normalize: false}).pkg;
+				const {pkg} = readPkgUp.sync({cwd: module.context, normalize: false});
 				const engines = Object.assign({}, pkg.engines);
 
 				range = engines.node;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "github.com/SamVerschueren"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "scripts": {
     "test": "xo && ava"


### PR DESCRIPTION
Was previously receiving:

```
  lib/babel-module-template.js:8:7
  ✖   8:7   Use object destructuring.  prefer-destructuring
  ✖  39:11  Use object destructuring.  pre
```