### PR TITLE
Fix webpack 4 warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,9 +10,15 @@ class BabelEnginePlugin {
 	}
 
 	apply(compiler) {
-		compiler.plugin('compilation', compilation => {
-			compilation.moduleTemplate.apply(new BabelModuleTemplate(compilation, this._options));
-		});
+		if (compiler.hooks) {
+			compiler.hooks.compilation.tap('BabelEnginePlugin', compilation => {
+				new BabelModuleTemplate(compilation, this._options).apply(compilation.moduleTemplates.javascript);
+			});
+		} else {
+			compiler.plugin('compilation', compilation => {
+				compilation.moduleTemplate.apply(new BabelModuleTemplate(compilation, this._options));
+			});
+		}
 	}
 }
 

--- a/lib/babel-module-template.js
+++ b/lib/babel-module-template.js
@@ -28,7 +28,7 @@ class BabelModuleTemplate {
 	}
 
 	apply(moduleTemplate) {
-		moduleTemplate.plugin('module', (source, module) => {
+		const moduleFn = (source, module) => {
 			if (module.context !== null && module.context.indexOf(`${path.sep}node_modules${path.sep}`) === -1) {
 				return source;
 			}
@@ -58,7 +58,13 @@ class BabelModuleTemplate {
 			const result = babel.transform(source.source(), this._options.babel);
 
 			return new RawSource(result.code);
-		});
+		};
+
+		if (moduleTemplate.hooks) {
+			moduleTemplate.hooks.module.tap('BabelEnginePlugin', moduleFn);
+		} else {
+			moduleTemplate.plugin('module', moduleFn);
+		}
 	}
 }
 module.exports = BabelModuleTemplate;

--- a/test/fixtures/app.concat.js
+++ b/test/fixtures/app.concat.js
@@ -1,3 +1,3 @@
-import {process} from './lib'
+import {process} from './lib';
 
-process()
+process();

--- a/test/fixtures/lib.js
+++ b/test/fixtures/lib.js
@@ -2,5 +2,5 @@ import getUrls from 'get-urls';
 
 const text = 'Lorem ipsum dolor sit amet, //sindresorhus.com consectetuer adipiscing http://yeoman.io elit.';
 export function process() {
-    getUrls(text);
+	getUrls(text);
 }

--- a/test/fixtures/webpack.concat.config.js
+++ b/test/fixtures/webpack.concat.config.js
@@ -1,8 +1,8 @@
 'use strict';
 const path = require('path');
 const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
-const BabelEnginePlugin = require('../../');
-const webpack = require('webpack')
+const webpack = require('webpack');
+const BabelEnginePlugin = require('../..');
 
 module.exports = {
 	entry: path.join(__dirname, '/app.concat.js'),
@@ -17,4 +17,4 @@ module.exports = {
 		new webpack.optimize.ModuleConcatenationPlugin(),
 		new UglifyJSPlugin()
 	]
-}
+};

--- a/test/fixtures/webpack.config.js
+++ b/test/fixtures/webpack.config.js
@@ -1,7 +1,7 @@
 'use strict';
 const path = require('path');
 const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
-const BabelEnginePlugin = require('../../');
+const BabelEnginePlugin = require('../..');
 
 module.exports = {
 	entry: path.join(__dirname, '/app.js'),
@@ -15,4 +15,4 @@ module.exports = {
 		}),
 		new UglifyJSPlugin()
 	]
-}
+};

--- a/test/fixtures/webpack.verbose.config.js
+++ b/test/fixtures/webpack.verbose.config.js
@@ -1,7 +1,7 @@
 'use strict';
 const path = require('path');
 const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
-const BabelEnginePlugin = require('../../');
+const BabelEnginePlugin = require('../..');
 
 module.exports = {
 	entry: path.join(__dirname, '/app.js'),
@@ -17,4 +17,4 @@ module.exports = {
 		}),
 		new UglifyJSPlugin()
 	]
-}
+};


### PR DESCRIPTION
In webpack 4, `Tapable#apply`, `Tapable#plugin` and `Compilation.moduleTemplate` raise a deprecation notice.

- `Tapable#apply(plugin)` must be replaced by a call to `plugin.apply`
- `Tapable#plugin(hook, fn)` must be replaced by a call to `hook.tap` (or `hook.tapAsync`)
- `Compilation.moduleTemplate` must be replaced by `Compilation.moduleTemplates.javascript`

Fix https://github.com/SamVerschueren/babel-engine-plugin/issues/17