### PR TITLE
Add silent flag to disable warnings in console

### DIFF
--- a/lib/babel-module-template.js
+++ b/lib/babel-module-template.js
@@ -17,7 +17,12 @@ class BabelModuleTemplate {
 	}
 
 	warn(pkgName) {
-		if (this._options.plugin.verbose === false && logs.has(pkgName)) {
+		if (
+			this._options.plugin.verbose === false && (
+				logs.has(pkgName) ||
+				this._options.plugin.silent === true
+			)
+		) {
 			return;
 		}
 

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,13 @@ Default: `true`
 
 By disabling verbose logging, the plugin will only print the warning per package once.
 
+##### silent
+
+Type: `boolean`<br>
+Default: `false`
+
+By disabling verbose logging and enabling silent logging, the plugin will not print any warnings.
+
 
 ## Related
 


### PR DESCRIPTION
This PR addresses #11 and takes into account that author does not wish to entirely discard error messages (see discussion #13). Meaning that the warnings are ignored only when verbose is set as false and silent as true.  