### PR TITLE
Support Babel 7

### DIFF
--- a/ava.config.js
+++ b/ava.config.js
@@ -1,0 +1,6 @@
+export default {
+	files: [
+		'test/**/*',
+		'!test/fixtures'
+	]
+};

--- a/lib/babel-module-template.js
+++ b/lib/babel-module-template.js
@@ -1,6 +1,6 @@
 'use strict';
 const path = require('path');
-const babel = require('babel-core');
+const babel = require('@babel/core');
 const sources = require('webpack-sources');
 const readPkgUp = require('read-pkg-up');
 const semver = require('semver');

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@babel/preset-env": "^7.4.5",
-    "ava": "*",
+    "ava": "^1",
     "get-urls": "^7.0.0",
     "pify": "^2.3.0",
     "uglifyjs-webpack-plugin": "^0.4.0",
@@ -44,7 +44,10 @@
   },
   "xo": {
     "rules": [
-      ["ava/no-import-test-files", false]
+      [
+        "ava/no-import-test-files",
+        false
+      ]
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,5 +41,10 @@
     "uglifyjs-webpack-plugin": "^0.4.0",
     "webpack": "^3.1.0",
     "xo": "*"
+  },
+  "xo": {
+    "rules": [
+      ["ava/no-import-test-files", false]
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,14 +28,14 @@
     "engine"
   ],
   "dependencies": {
-    "babel-core": "^6.24.0",
+    "@babel/core": "^7.4.5",
     "read-pkg-up": "^2.0.0",
     "semver": "^5.3.0",
     "webpack-sources": "^0.2.3"
   },
   "devDependencies": {
+    "@babel/preset-env": "^7.4.5",
     "ava": "*",
-    "babel-preset-env": "^1.3.2",
     "get-urls": "^7.0.0",
     "pify": "^2.3.0",
     "uglifyjs-webpack-plugin": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-engine-plugin",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Webpack plugin that transpiles dependencies targeting Node.js versions newer than Node.js 0.10",
   "license": "MIT",
   "repository": "SamVerschueren/babel-engine-plugin",

--- a/test/fixtures/webpack.concat.config.js
+++ b/test/fixtures/webpack.concat.config.js
@@ -12,7 +12,7 @@ module.exports = {
 	},
 	plugins: [
 		new BabelEnginePlugin({
-			presets: ['env']
+			presets: ['@babel/preset-env']
 		}),
 		new webpack.optimize.ModuleConcatenationPlugin(),
 		new UglifyJSPlugin()

--- a/test/fixtures/webpack.config.js
+++ b/test/fixtures/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
 	},
 	plugins: [
 		new BabelEnginePlugin({
-			presets: ['env']
+			presets: ['@babel/preset-env']
 		}),
 		new UglifyJSPlugin()
 	]

--- a/test/fixtures/webpack.verbose.config.js
+++ b/test/fixtures/webpack.verbose.config.js
@@ -11,7 +11,7 @@ module.exports = {
 	},
 	plugins: [
 		new BabelEnginePlugin({
-			presets: ['env']
+			presets: ['@babel/preset-env']
 		}, {
 			verbose: false
 		}),


### PR DESCRIPTION
This adds support for Babel 7 (fixes https://github.com/SamVerschueren/babel-engine-plugin/issues/16), by upgrading the two relevant packages (`babel-core`->`@babel/core` and `babel-preset-env`->`@babel/preset-env`).

This was surprisingly easier than I expected!

I ran into an issue running tests (perhaps because I'm using a newer version of `ava`?), so I had to add a config to ignore the `fixtures/` files.

I've tested this with our internal app and it works great.